### PR TITLE
Food now gives 300 extra life

### DIFF
--- a/GORLibrary/robot.py
+++ b/GORLibrary/robot.py
@@ -83,7 +83,10 @@ class robot(object):
 		if(dist<=(self.bboxSize+obj.bboxSize)):
 			if obj.eatable:
 				print("miam")
-				self.lifeValue += 100
+				self.lifeValue += 300
+				if (self.lifeValue > 10000):
+					print "Robot too efficient has been killed by jealous crowd"
+					self.lifeValue = 0
 			else:
 				print("beurk")
 			return obj.eatable


### PR DESCRIPTION
Food now gives 300 extra life instead of 100.
Beware of not becoming too healthy: an angry crowd will kill the robot as soon as it gets more than 10,000 life points.
